### PR TITLE
Add CI workflow for build and tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake
+      - name: Configure
+        run: |
+          mkdir build
+          cd build
+          ../configure -ut
+      - name: Build
+        run: |
+          cd build
+          cmake --build . -- -j$(nproc)
+      - name: Run tests
+        run: |
+          cd build
+          ./mips_ut
+

--- a/include/mips_sim/assembler/assembler.h
+++ b/include/mips_sim/assembler/assembler.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <list>
 #include <unordered_map>
+#include <cstdint>
 #include "mips_sim/assembler/parser.h"
 
 class Assembler

--- a/include/mips_sim/cpu/register_file.h
+++ b/include/mips_sim/cpu/register_file.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include "mips_sim/log.h"
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build the project and run unit tests
- include `<cstdint>` in headers that use fixed width types

## Testing
- `../configure -ut` & `cmake --build .`
- `./mips_ut`

------
https://chatgpt.com/codex/tasks/task_e_686dfcd60b088330833aadce42ac9ff1